### PR TITLE
Add multiple healthchecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ dist
 *.swo
 .DS_Store
 .cache
+.idea
 

--- a/polaris_health/monitors/__init__.py
+++ b/polaris_health/monitors/__init__.py
@@ -60,10 +60,12 @@ class BaseMonitor:
 from .http import HTTP
 from .tcp import TCP
 from .forced import Forced
+from .external import External
 
 registered = {
     'http': HTTP,
     'tcp': TCP,
     'forced': Forced,
+    'external': External,
 }            
 

--- a/polaris_health/monitors/external.py
+++ b/polaris_health/monitors/external.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+import subprocess
+
+from polaris_health import Error, MonitorFailed
+from . import BaseMonitor
+
+
+__all__ = [ 'External' ]
+
+LOG = logging.getLogger(__name__)
+LOG.addHandler(logging.NullHandler())
+
+
+class External(BaseMonitor):
+
+    """External script monitor base"""
+
+    def __init__(self, port, file_path, result=None, args=None,
+                 interval=10, timeout=5, retries=2):
+        """
+        args:
+            port: int, port number
+            file_path: string, the full file path to the external check,
+                starting at /, must be executable
+            args: list, additional command line arguments to be passed to
+            the external check
+            result: a string to check against the result of the executed script
+                any other response will mean a failure.
+            Other args as per BaseMonitor() spec
+        """
+        super(External, self).__init__(interval=interval, timeout=timeout,
+                                      retries=retries)
+
+        # name to show in generic state export
+        self.name = 'external'
+
+        ### port ###
+        self.port = port
+        if not isinstance(port, int) or port < 1 or port > 65535:
+            log_msg = ('port "{}" must be an integer between 1 and 65535'.
+                       format(port))
+            LOG.error(log_msg)
+            raise Error(log_msg)
+        ### file path ###
+        if os.path.isfile(file_path):
+            ## check if file is executable
+            if not os.access(file_path, os.X_OK):
+                log_msg = ('file_path "{}" file path is not executable'.
+                           format(file_path))
+                LOG.error(log_msg)
+                raise Error(log_msg)
+            self.file_path = file_path
+        else:
+            log_msg = ('file_path "{}" cannot be found on the system'.
+                       format(file_path))
+            LOG.error(log_msg)
+            raise Error(log_msg)
+        ### args ###
+        if isinstance(args, list):
+            self.args = args
+        else:
+            self.args = []
+        ### result ###
+        if type(result) != str:
+            log_msg = 'result is not set or is not a string'
+            LOG.error(log_msg)
+            raise Error(log_msg)
+        self.result = result.strip()
+
+    def run(self, dst_ip):
+        """
+        Execute a shell command script
+        Check response matches the result string
+        args:
+            dst_ip: string, IP address to connect to
+        returns:
+            None
+
+        raises:
+            MonitorFailed() on process timeout or if output does not match result string
+            or command returns a non 0 response.
+        """
+        try:
+            cmd = subprocess.run([], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                        timeout=self.timeout)
+        except subprocess.TimeoutExpired as e:
+            log_msg = ('command timeout reached: {error}'
+                       .format(error=e))
+            raise MonitorFailed(log_msg)
+        except subprocess.SubprocessError as e:
+            raise MonitorFailed(e)
+
+        if cmd.returncode == 0:
+            if cmd.stdout.rstrip() == self.result:
+                return
+            else:
+                log_msg = ('The external check returned:{} not {}'.format(cmd.stdout, self.result))
+                raise MonitorFailed(log_msg)
+        else:
+            log_msg = ('External Check Failed: Reason: {}'.format(cmd.stderr))
+            raise MonitorFailed(log_msg)

--- a/polaris_health/monitors/external.py
+++ b/polaris_health/monitors/external.py
@@ -78,13 +78,14 @@ class External(BaseMonitor):
             dst_ip: string, IP address to connect to
         returns:
             None
-
         raises:
             MonitorFailed() on process timeout or if output does not match result string
             or command returns a non 0 response.
         """
+        # force what ever args into strings or subprocess.run will crash
+        command = list(map(str, [self.file_path, dst_ip, self.port] + self.args))
         try:
-            cmd = subprocess.run([], universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cmd = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                         timeout=self.timeout)
         except subprocess.TimeoutExpired as e:
             log_msg = ('command timeout reached: {error}'
@@ -97,8 +98,8 @@ class External(BaseMonitor):
             if cmd.stdout.rstrip() == self.result:
                 return
             else:
-                log_msg = ('The external check returned:{} not {}'.format(cmd.stdout, self.result))
+                log_msg = ('The external check returned:{} not {}'.format(cmd.stdout.rstrip(), self.result))
                 raise MonitorFailed(log_msg)
         else:
-            log_msg = ('External Check Failed: Reason: {}'.format(cmd.stderr))
+            log_msg = ('External Check Failed: Reason: {}'.format(cmd.stderr.rstrip()))
             raise MonitorFailed(log_msg)


### PR DESCRIPTION
Hi all. I have created an external health check to expand the current HTTP/S and TCP healthchecks. It essentially gives the ability to run an external script and mark a server as up or down based on the result. So you can run multiple or more complex health checks than are currently available. For the health check to pass the script must exit with a code of 0 as well as return a string that is matched against the one in the configuration, an exit code of anything other than 0 will result in a failure as well as returning a non matching string.  

To enable it I have added the following extra configuration options.
monitor: external
monitor_params:
     result: success (it checks for a string returned from the script. matches what is declared here. So in this example it is looking to get back the word 'success' from the script. Anything else will be deemed a failure and logged so you can work out what is going wrong. You can invoke a healthcheck failure by returning a string that is not declared in the result section or by returning a non zero exit status both log the same result and you can hopefully see why your script is failing.) 
     port: 80
     file_path: /root/externalCheck.sh
     args: ['test1','test2'] (these are optional just a list of additional parameters you may wish to pass in. This value is not required. The others are)
The other variables like timeout and retries work as expected.

The params are passed into the shell script as standard args 
$1 is the ip address
$2 is the port number
$3 and beyond are the parameters that you set in the args list you can add as many as you like. 

Comments and suggestions are welcome. 